### PR TITLE
ViewModel Template Evolution

### DIFF
--- a/templates/Ackee/View Model.xctemplate/___FILEBASENAME___.swift
+++ b/templates/Ackee/View Model.xctemplate/___FILEBASENAME___.swift
@@ -8,19 +8,33 @@
 
 import ReactiveSwift
 
-protocol ___FILEBASENAMEASIDENTIFIER___ing {
-
+// MARK: Protocols
+protocol ___FILEBASENAMEASIDENTIFIER___Inputs {
 }
 
-class ___FILEBASENAMEASIDENTIFIER___: ___FILEBASENAMEASIDENTIFIER___ing {
+protocol ___FILEBASENAMEASIDENTIFIER___Outputs {
+}
 
+protocol ___FILEBASENAMEASIDENTIFIER___Actions {
+}
+
+protocol ___FILEBASENAMEASIDENTIFIER___ing {
+    var inputs: ___FILEBASENAMEASIDENTIFIER___Inputs { get }
+    var outputs: ___FILEBASENAMEASIDENTIFIER___Outputs { get }
+    var actions: ___FILEBASENAMEASIDENTIFIER___Actions { get }
+}
+
+// MARK: ___FILEBASENAMEASIDENTIFIER___
+final class ___FILEBASENAMEASIDENTIFIER___: ___FILEBASENAMEASIDENTIFIER___ing, ___FILEBASENAMEASIDENTIFIER___Inputs, ___FILEBASENAMEASIDENTIFIER___Outputs, ___FILEBASENAMEASIDENTIFIER___Actions {
+    private let (lifetime, token) = Lifetime.make()
+    
+    var inputs: ___FILEBASENAMEASIDENTIFIER___Inputs { return self }
+    var outputs: ___FILEBASENAMEASIDENTIFIER___Outputs { return self }
+    var actions: ___FILEBASENAMEASIDENTIFIER___Actions { return self }
+    
+    // MARK: Dependencies
+    
     // MARK: Initializers
-    required init(){
-        setupBindings()
-    }
-
-    // MARK: Helpers
-    private func setupBindings() {
-
+    required init() {
     }
 }


### PR DESCRIPTION
This is a ViewModel inspired by Kickstarter's ViewModels and our own.

New style of ViewModels -separating inputs, outputs, and actions[inputs should generally be function calls/mutableproperties/signals, outputs should be signalproducers/properties and actions are for ReactiveSwift Action. Note that instead of writing viewModel.saveAction we can now write viewModel.actions.save]. added lifetime support and removed setupBindigs - we should separate logic into lazy properties, signalProducers, etc  

As this change is bigger we should discuss if we want this template on all projects