### PR TITLE
Remove setupBindings in VM.

### DIFF
--- a/templates/Ackee/ViewController + ViewModel.xctemplate/default/___FILEBASENAME___ViewModel.swift
+++ b/templates/Ackee/ViewController + ViewModel.xctemplate/default/___FILEBASENAME___ViewModel.swift
@@ -29,13 +29,5 @@ final class ___FILEBASENAMEASIDENTIFIER___: ___VARIABLE_modelSubclass___, ___FIL
 
     init(dependencies: Dependencies) {
         super.init()
-
-        setupBindings()
-    }
-
-    // MARK: - Helpers
-    
-    private func setupBindings() {
-
     }
 }

--- a/templates/Ackee/ViewController + ViewModel.xctemplate/isGeneric/___FILEBASENAME___ViewModel.swift
+++ b/templates/Ackee/ViewController + ViewModel.xctemplate/isGeneric/___FILEBASENAME___ViewModel.swift
@@ -29,13 +29,5 @@ final class ___FILEBASENAMEASIDENTIFIER___: ___VARIABLE_modelSubclass___, ___FIL
 
     init(dependencies: Dependencies) {
         super.init()
-
-        setupBindings()
-    }
-
-    // MARK: - Helpers
-    
-    private func setupBindings() {
-
     }
 }

--- a/templates/Ackee/ViewModel.xctemplate/___FILEBASENAME___.swift
+++ b/templates/Ackee/ViewModel.xctemplate/___FILEBASENAME___.swift
@@ -28,13 +28,5 @@ final class ___FILEBASENAMEASIDENTIFIER___: ___VARIABLE_modelSubclass___, ___FIL
 
     init(dependencies: Dependencies) {
         super.init()
-
-        setupBindings()
-    }
-
-    // MARK: - Helpers
-    
-    private func setupBindings() {
-
     }
 }


### PR DESCRIPTION
This PR deletes `setupBindings()` in view models, as that is something that we do not use very often.